### PR TITLE
Add a warning when declaring `__div__` or `__idiv__` in Python 2.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,8 +26,11 @@ install:
   - pip --version
   - tox --version
   - coverage --version
-  - pip install -U setuptools
 script:
+    # Test install with current version of setuptools
+  - pip install .
+    # Run the tests with newest version of setuptools
+  - pip install -U setuptools
   - tox -e coverage-erase,$TOXENV
 after_success:
   - tox -e coveralls

--- a/CONTRIBUTORS.txt
+++ b/CONTRIBUTORS.txt
@@ -108,3 +108,5 @@ Order doesn't matter (not that much, at least ;)
 * Yuri Bochkarev: Added epytext support to docparams extension.
 
 * Alexander Todorov: added new errro conditions to 'bad-super-call'.
+
+* Roy Williams (Lyft): added check for implementing __eq__ without implementing __hash__.

--- a/doc/whatsnew/2.0.rst
+++ b/doc/whatsnew/2.0.rst
@@ -153,6 +153,65 @@ New checkers
   Other places where this check looks are *with* statement name bindings and
   except handler's name binding.
 
+* A new Python 3 check was added, ``eq-without-hash``, which enforces classes that implement
+  ``__eq__`` *also* implement ``__hash__``.  The behavior around classes which implement ``__eq__``
+  but not ``__hash__`` changed in Python 3; in Python 2 such classes would get ``object.__hash__``
+  as their default implementation.  In Python 3, aforementioned classes get ``None`` as their
+  implementation thus making them unhashable.
+
+  .. code-block:: python
+
+      class JustEq(object):
+         def __init__(self, x):
+           self.x = x
+
+         def __eq__(self, other):
+           return self.x == other.x
+
+      class Neither(object):
+        def __init__(self, x):
+          self.x = x
+
+      class HashAndEq(object):
+         def __init__(self, x):
+           self.x = x
+
+         def __eq__(self, other):
+           return self.x == other.x
+
+         def __hash__(self):
+           return hash(self.x)
+
+      {Neither(1), Neither(2)}  # OK in Python 2 and Python 3
+      {HashAndEq(1), HashAndEq(2)}  # OK in Python 2 and Python 3
+      {JustEq(1), JustEq(2)}  # Works in Python 2, throws in Python 3
+
+
+  In general, this is a poor practice which motivated the behavior change.
+
+  .. code-block:: python
+
+      as_set = {JustEq(1), JustEq(2)}
+      print(JustEq(1) in as_set)  # prints False
+      print(JustEq(1) in list(as_set))  # prints True
+
+
+  In order to fix this error and avoid behavior differences between Python 2 and Python 3, classes
+  should either explicitly set ``__hash__`` to ``None`` or implement a hashing function.
+
+  .. code-block:: python
+
+      class JustEq(object):
+         def __init__(self, x):
+           self.x = x
+
+         def __eq__(self, other):
+           return self.x == other.x
+
+         __hash__ = None
+
+      {JustEq(1), JustEq(2)}  # Now throws an exception in both Python 2 and Python 3.
+
 Other Changes
 =============
 

--- a/pylint/__pkginfo__.py
+++ b/pylint/__pkginfo__.py
@@ -7,10 +7,14 @@
 
 # pylint: disable=W0622,C0103
 """pylint packaging information"""
+
 from __future__ import absolute_import
 
 from os.path import join
+from sys import version_info as py_version
 
+from pkg_resources import parse_version
+from setuptools import __version__ as setuptools_version
 
 modname = distname = 'pylint'
 
@@ -31,8 +35,25 @@ dependency_links = [
 
 extras_require = {}
 extras_require[':sys_platform=="win32"'] = ['colorama']
-extras_require[':python_version=="2.7"'] = ['configparser', 'backports.functools_lru_cache']
-extras_require[':python_version<"3.4"'] = ['singledispatch']
+
+
+def has_environment_marker_range_operators_support():
+    """Code extracted from 'pytest/setup.py'
+    https://github.com/pytest-dev/pytest/blob/7538680c/setup.py#L31
+    The first known release to support environment marker with range operators
+    it is 17.1, see: https://setuptools.readthedocs.io/en/latest/history.html#id113
+    """
+    return parse_version(setuptools_version) >= parse_version('17.1')
+
+
+if has_environment_marker_range_operators_support():
+    extras_require[':python_version=="2.7"'] = ['configparser', 'backports.functools_lru_cache']
+    extras_require[':python_version<"3.4"'] = ['singledispatch']
+else:
+    if (py_version.major, py_version.minor) == (2, 7):
+        install_requires.extend(['configparser', 'backports.functools_lru_cache'])
+    if py_version < (3, 4):
+        install_requires.extend(['singledispatch'])
 
 
 license = 'GPL'

--- a/pylint/checkers/python3.py
+++ b/pylint/checkers/python3.py
@@ -333,6 +333,12 @@ class Python3Checker(checkers.BaseChecker):
                   'Python 3. Using either `key` or `functools.cmp_to_key` '
                   'should be preferred.',
                   {'maxversion': (3, 0)}),
+        'W1641': ('Implementing __eq__ without also implementing __hash__',
+                  'eq-without-hash',
+                  'Used when a class implements __eq__ but not __hash__.  In Python 2, objects '
+                  'get object.__hash__ as the default implementation, in Python 3 objects get '
+                  'None as their default __hash__ implementation if they also implement __eq__.',
+                  {'maxversion': (3, 0)}),
     }
 
     _bad_builtins = frozenset([
@@ -426,6 +432,9 @@ class Python3Checker(checkers.BaseChecker):
     def visit_classdef(self, node):
         if '__metaclass__' in node.locals:
             self.add_message('metaclass-assignment', node=node)
+        locals_and_methods = set(node.locals).union(x.name for x in node.mymethods())
+        if '__eq__' in locals_and_methods and '__hash__' not in locals_and_methods:
+            self.add_message('eq-without-hash', node=node)
 
     @utils.check_messages('old-division')
     def visit_binop(self, node):

--- a/pylint/test/unittest_checker_python3.py
+++ b/pylint/test/unittest_checker_python3.py
@@ -215,6 +215,37 @@ class Python3CheckerTest(testutils.CheckerTestCase):
     def test_cmp_method(self):
         self.defined_method_test('cmp', 'cmp-method')
 
+    def test_eq_and_hash_method(self):
+        """Helper for verifying that a certain method is not defined."""
+        node = astroid.extract_node("""
+            class Foo(object):  #@
+                def __eq__(self, other):
+                    pass
+                def __hash__(self):
+                    pass""")
+        with self.assertNoMessages():
+            self.checker.visit_classdef(node)
+
+    def test_eq_and_hash_is_none(self):
+        """Helper for verifying that a certain method is not defined."""
+        node = astroid.extract_node("""
+            class Foo(object):  #@
+                def __eq__(self, other):
+                    pass
+                __hash__ = None""")
+        with self.assertNoMessages():
+            self.checker.visit_classdef(node)
+
+    def test_eq_without_hash_method(self):
+        """Helper for verifying that a certain method is not defined."""
+        node = astroid.extract_node("""
+            class Foo(object):  #@
+                def __eq__(self, other):
+                    pass""")
+        message = testutils.Message('eq-without-hash', node=node)
+        with self.assertAddsMessages(message):
+            self.checker.visit_classdef(node)
+
     @python2_only
     def test_print_statement(self):
         node = astroid.extract_node('print "Hello, World!" #@')


### PR DESCRIPTION
These methdos are removed in Python 3 in favor of `__floordiv__` and `__truediv__`
